### PR TITLE
Updates pakage.json to pin dependacy

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@angular/core": "^4.0.0",
     "@angular/forms": "^4.0.0",
     "@angular/http": "^4.0.0",
-    "@angular/material": "^2.0.0-beta.3",
+    "@angular/material": "2.0.0-beta.3",
     "@angular/platform-browser": "^4.0.0",
     "@angular/platform-browser-dynamic": "^4.0.0",
     "@angular/router": "^4.0.0",


### PR DESCRIPTION
This change pins @angular/material to 2.0.0-beta.3. 

[In the current version of @angular/material (2.0.0-beta11) `MaterialModule` has been removed.](https://github.com/angular/material2/blob/master/CHANGELOG.md#materialmodule)

When I run the with the current version I get the following error.
```
WARNING in ./src/app/app.module.ts
33:12-26 "export 'MaterialModule' was not found in '@angular/material'

ERROR in /Users/rmalecky/Code/aws-cognito-apigw-angular/src/app/app.module.ts (7,10): Module '"/Users/rmalecky/Code/aws-cognito-apigw-angular/node_modules/@angular/material/material"' has no exported member 'MaterialModule'.

ERROR in MaterialModule is not an NgModule
```

Requiring version 2.0.0-beta3 resolves the error.
